### PR TITLE
Use input mtime as date in man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ $(OPTIONS_1_INC): $(GEN_MANPAGE_OPTS)
 $(MANPAGE_not_gzipped): nvidia-xconfig.1.m4 $(OPTIONS_1_INC) $(VERSION_MK)
 	$(call quiet_cmd,M4) -D__HEADER__=$(AUTO_TEXT) -I $(OUTPUTDIR) \
 	  -D__VERSION__=$(NVIDIA_VERSION) \
-	  -D__DATE__="`$(DATE) +%F`" \
+	  -D__DATE__="`$(DATE) -u -r nvidia-xconfig.1.m4 +%F || $(DATE) +%F`" \
 	  -D__BUILD_OS__=$(TARGET_OS) \
 	  $< > $@
 


### PR DESCRIPTION
Use (nvidia-xconfig.1.m4) input mtime as date in man page.
See https://reproducible-builds.org/ for why this is good

This date call is designed to work with different flavors of 'date' (GNU, BSD, Solaris).

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.